### PR TITLE
Adicionando o tamanho do arquivo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Além disso, sua aplicação deve ser original e não pode ser uma cópia de out
 
 Sua aplicação deve ser capaz de rodar o máximo possível de arquivos de teste na pasta disponibilizada, carregando 1 por vez. Os arquivos disponíveis são:
 
-- alltypes.json
-- verysmall.json
-- small.json
-- pokedex.json
-- startwitharray.json
-- large.json
-- giant.json
-- invalid.json
-- nullreference.json
+- verysmall.json - 98 bytes
+- alltypes.json - 804 bytes
+- small.json - 1 KB
+- invalid.json - 1 KB
+- nullreference.json - 21 KB
+- pokedex.json - 281 KB
+- startwitharray.json - 1,6 MB
+- large.json - 24,9 MB
+- giant.json - 181 MB
 
 ## Submeter seu projeto
 


### PR DESCRIPTION
Na hora de testar minha solução organizei os arquivos em ordem crescente de tamanho para verificar até onde meu MVP estava renderizando corretamente. Creio que essa informação irá auxiliar outros participantes da rinha também 😁

Nesse primeiro momento o tamanho está localizado após o nome do arquivo, porém podemos organizar o nome e tamanho em uma tabela, caso essa seja uma opção mais organizada visualmente 😉